### PR TITLE
feat: Add Library/Documents feature

### DIFF
--- a/pwd_manager/__init__.py
+++ b/pwd_manager/__init__.py
@@ -1,30 +1,33 @@
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+from dotenv import load_dotenv
 from flask import Flask, render_template
-from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
 from flask_migrate import Migrate
-from dotenv import load_dotenv
-import os
-import logging
-from logging.handlers import RotatingFileHandler
+from flask_sqlalchemy import SQLAlchemy
 
 # Initialize extensions
 db = SQLAlchemy()
 bcrypt = Bcrypt()
 migrate = Migrate()
 
+
 def create_app(config_name=None):
     # Load environment variables based on config
     # Priority: .env.local > .env.{config_name} > .env
-    env_file = '.env'
-    if config_name and config_name != 'testing':
-        env_file = f'.env.{config_name}'
-    
+    env_file = ".env"
+    if config_name and config_name != "testing":
+        env_file = f".env.{config_name}"
+
     # Check for .env.local first (highest priority for local development)
     from pathlib import Path
+
     base_dir = Path(__file__).resolve().parent.parent
-    local_env = base_dir / '.env.local'
+    local_env = base_dir / ".env.local"
     config_env = base_dir / env_file
-    
+
     if local_env.exists():
         load_dotenv(local_env, override=True)
         print(f"Loaded environment from: {local_env}")
@@ -34,40 +37,42 @@ def create_app(config_name=None):
     else:
         load_dotenv()  # Default .env
         print("Loaded environment from: .env")
-    
+
     # Initialize Flask app
     app = Flask(__name__)
-    
-    if config_name == 'testing':
+
+    if config_name == "testing":
         # Testing configuration
-        app.config['TESTING'] = True
-        app.config['SECRET_KEY'] = 'test-secret-key'
-        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-        app.config['WTF_CSRF_ENABLED'] = False  # Disable CSRF for testing
+        app.config["TESTING"] = True
+        app.config["SECRET_KEY"] = "test-secret-key"
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        app.config["WTF_CSRF_ENABLED"] = False  # Disable CSRF for testing
     else:
         # Production configuration
-        app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', os.urandom(24))
-        
+        app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", os.urandom(24))
+
         # Configure database
-        db_type = os.getenv('DATABASE_TYPE', 'sqlite')
-        db_path = os.getenv('DATABASE_PATH', os.path.join(app.instance_path, 'passwords.db'))
-        
+        db_type = os.getenv("DATABASE_TYPE", "sqlite")
+        db_path = os.getenv(
+            "DATABASE_PATH", os.path.join(app.instance_path, "passwords.db")
+        )
+
         # Ensure the directory exists
         os.makedirs(os.path.dirname(db_path), exist_ok=True)
-        
+
         # Construct database URL
-        if db_type == 'sqlite':
-            app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
+        if db_type == "sqlite":
+            app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{db_path}"
         else:
-            raise ValueError(f'Unsupported database type: {db_type}')
-    
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    
+            raise ValueError(f"Unsupported database type: {db_type}")
+
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
     # Configure attachments directory
-    attachments_dir = os.path.join(app.instance_path, 'attachments')
+    attachments_dir = os.path.join(app.instance_path, "attachments")
     os.makedirs(attachments_dir, exist_ok=True)
-    app.config['ATTACHMENTS_DIR'] = attachments_dir
-    app.config['MAX_CONTENT_LENGTH'] = 10 * 1024 * 1024  # 10MB max upload size
+    app.config["ATTACHMENTS_DIR"] = attachments_dir
+    app.config["MAX_CONTENT_LENGTH"] = 10 * 1024 * 1024  # 10MB max upload size
 
     # Initialize extensions with app
     db.init_app(app)
@@ -76,10 +81,12 @@ def create_app(config_name=None):
 
     # Register blueprints
     from pwd_manager.auth.routes import auth_bp
+    from pwd_manager.library.routes import library_bp
     from pwd_manager.routes import main_bp
-    
-    app.register_blueprint(auth_bp, url_prefix='/auth')
+
+    app.register_blueprint(auth_bp, url_prefix="/auth")
     app.register_blueprint(main_bp)
+    app.register_blueprint(library_bp, url_prefix="/library")
 
     # Register Jinja2 filters
     register_template_filters(app)
@@ -89,7 +96,7 @@ def create_app(config_name=None):
         db.create_all()
 
     # Configure logging (only in non-debug mode or if explicitly enabled)
-    if not app.debug or os.getenv('ENABLE_FILE_LOGGING', 'false').lower() == 'true':
+    if not app.debug or os.getenv("ENABLE_FILE_LOGGING", "false").lower() == "true":
         configure_logging(app)
 
     # Register error handlers
@@ -101,61 +108,58 @@ def create_app(config_name=None):
 def configure_logging(app):
     """Configure file-based logging with rotation"""
     from pathlib import Path
-    
+
     # Create logs directory
-    logs_dir = Path(app.instance_path) / 'logs'
+    logs_dir = Path(app.instance_path) / "logs"
     logs_dir.mkdir(exist_ok=True)
-    
+
     # Configure rotating file handler (max 10MB per file, keep 10 backups)
     file_handler = RotatingFileHandler(
-        logs_dir / 'pwd_manager.log',
-        maxBytes=10 * 1024 * 1024,  # 10MB
-        backupCount=10
+        logs_dir / "pwd_manager.log", maxBytes=10 * 1024 * 1024, backupCount=10  # 10MB
     )
-    file_handler.setFormatter(logging.Formatter(
-        '%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
-    ))
+    file_handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]"
+        )
+    )
     file_handler.setLevel(logging.ERROR)
-    
+
     app.logger.addHandler(file_handler)
     app.logger.setLevel(logging.INFO)
-    app.logger.info('Password Manager startup')
+    app.logger.info("Password Manager startup")
 
 
 def register_error_handlers(app):
     """Register custom error handlers"""
-    
+
     @app.errorhandler(404)
     def not_found_error(error):
-        return render_template('errors/404.html'), 404
-    
+        return render_template("errors/404.html"), 404
+
     @app.errorhandler(500)
     def internal_error(error):
         db.session.rollback()  # Roll back any failed transactions
-        app.logger.error(f'Server Error: {error}', exc_info=True)
-        return render_template('errors/500.html'), 500
-    
+        app.logger.error(f"Server Error: {error}", exc_info=True)
+        return render_template("errors/500.html"), 500
+
     @app.errorhandler(Exception)
     def handle_exception(error):
         # Log the full exception
-        app.logger.error(f'Unhandled Exception: {error}', exc_info=True)
+        app.logger.error(f"Unhandled Exception: {error}", exc_info=True)
         db.session.rollback()
-        return render_template('errors/500.html'), 500
+        return render_template("errors/500.html"), 500
 
 
 def register_template_filters(app):
     """Register custom Jinja2 template filters"""
     import markdown
     from markupsafe import Markup
-    
-    @app.template_filter('markdown')
+
+    @app.template_filter("markdown")
     def markdown_filter(text):
         """Convert markdown text to HTML"""
         if not text:
-            return ''
+            return ""
         # Convert markdown to HTML with safe extensions
-        html = markdown.markdown(
-            text,
-            extensions=['fenced_code', 'tables', 'nl2br']
-        )
+        html = markdown.markdown(text, extensions=["fenced_code", "tables", "nl2br"])
         return Markup(html)

--- a/pwd_manager/library/routes.py
+++ b/pwd_manager/library/routes.py
@@ -1,0 +1,570 @@
+import base64
+import mimetypes
+import uuid
+from datetime import datetime
+from io import BytesIO
+from pathlib import Path
+
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    session,
+    url_for,
+)
+
+from pwd_manager import db
+from pwd_manager.models import Document, DocumentAttachment
+from pwd_manager.utils.auth import get_user_encryption_key
+from pwd_manager.utils.crypto import (
+    decrypt_binary,
+    decrypt_data,
+    encrypt_binary,
+    encrypt_data,
+)
+
+library_bp = Blueprint("library", __name__)
+
+
+def _delete_attachment_file(attachment):
+    """Remove the on-disk encrypted file for an attachment."""
+    storage_path = (
+        Path(current_app.config["ATTACHMENTS_DIR"]) / attachment.storage_filename
+    )
+    if storage_path.exists():
+        storage_path.unlink()
+
+
+@library_bp.route("/")
+def index():
+    if "user_id" not in session:
+        return redirect(url_for("auth.login"))
+
+    documents = (
+        Document.query.filter_by(user_id=session["user_id"], is_draft=False)
+        .order_by(Document.updated_at.desc())
+        .all()
+    )
+    return render_template("library/index.html", documents=documents)
+
+
+@library_bp.route("/add", methods=["GET", "POST"])
+def add_document():
+    if "user_id" not in session:
+        return redirect(url_for("auth.login"))
+
+    user_id = session["user_id"]
+    encryption_key = get_user_encryption_key()
+    if not encryption_key:
+        flash("Error retrieving encryption key", "error")
+        return redirect(url_for("library.index"))
+
+    if request.method == "POST":
+        document_id = request.form.get("document_id")
+        document = Document.query.get_or_404(document_id)
+
+        if document.user_id != user_id or not document.is_draft:
+            flash("Unauthorized or invalid document", "error")
+            return redirect(url_for("library.index"))
+
+        title = request.form.get("title")
+        content = request.form.get("content", "")
+        if not title:
+            flash("Title is required", "error")
+            return render_template(
+                "library/document_form.html",
+                document=document,
+                content=content,
+                form_action=url_for("library.add_document"),
+                cancel_url=url_for("library.cancel_document", doc_id=document.id),
+                page_title="Add New Document",
+            )
+
+        document.title = title
+        document.encrypted_content = (
+            encrypt_data(encryption_key, content) if content else None
+        )
+        document.is_draft = False
+        document.updated_at = datetime.utcnow()
+        db.session.commit()
+
+        flash("Document saved successfully!", "success")
+        return redirect(url_for("library.view_document", doc_id=document.id))
+
+    # Clean up any leftover drafts for this user before creating a new one
+    old_drafts = Document.query.filter_by(user_id=user_id, is_draft=True).all()
+    for draft in old_drafts:
+        for attachment in list(draft.attachments):
+            _delete_attachment_file(attachment)
+        db.session.delete(draft)
+    db.session.commit()
+
+    draft = Document(
+        user_id=user_id,
+        title="",
+        encrypted_content=None,
+        is_draft=True,
+    )
+    db.session.add(draft)
+    db.session.commit()
+
+    return render_template(
+        "library/document_form.html",
+        document=draft,
+        content="",
+        form_action=url_for("library.add_document"),
+        cancel_url=url_for("library.cancel_document", doc_id=draft.id),
+        page_title="Add New Document",
+    )
+
+
+@library_bp.route("/cancel/<int:doc_id>")
+def cancel_document(doc_id):
+    if "user_id" not in session:
+        return redirect(url_for("auth.login"))
+
+    document = Document.query.get_or_404(doc_id)
+    if document.user_id != session["user_id"] or not document.is_draft:
+        flash("Unauthorized or invalid document", "error")
+        return redirect(url_for("library.index"))
+
+    for attachment in list(document.attachments):
+        _delete_attachment_file(attachment)
+    db.session.delete(document)
+    db.session.commit()
+
+    return redirect(url_for("library.index"))
+
+
+@library_bp.route("/<int:doc_id>")
+def view_document(doc_id):
+    if "user_id" not in session:
+        return redirect(url_for("auth.login"))
+
+    document = Document.query.get_or_404(doc_id)
+    if document.user_id != session["user_id"] or document.is_draft:
+        flash("Unauthorized or invalid document", "error")
+        return redirect(url_for("library.index"))
+
+    encryption_key = get_user_encryption_key()
+    if not encryption_key:
+        flash("Error retrieving encryption key", "error")
+        return redirect(url_for("library.index"))
+
+    try:
+        content = (
+            decrypt_data(encryption_key, document.encrypted_content)
+            if document.encrypted_content
+            else ""
+        )
+        return render_template(
+            "library/view_document.html",
+            document=document,
+            content=content,
+        )
+    except Exception as exc:
+        current_app.logger.error(
+            f"Error decrypting document {doc_id}: {exc}", exc_info=True
+        )
+        flash("Error decrypting document content", "error")
+        return redirect(url_for("library.index"))
+
+
+@library_bp.route("/edit/<int:doc_id>", methods=["GET", "POST"])
+def edit_document(doc_id):
+    if "user_id" not in session:
+        return redirect(url_for("auth.login"))
+
+    document = Document.query.get_or_404(doc_id)
+    if document.user_id != session["user_id"] or document.is_draft:
+        flash("Unauthorized or invalid document", "error")
+        return redirect(url_for("library.index"))
+
+    encryption_key = get_user_encryption_key()
+    if not encryption_key:
+        flash("Error retrieving encryption key", "error")
+        return redirect(url_for("library.index"))
+
+    if request.method == "POST":
+        title = request.form.get("title")
+        if not title:
+            flash("Title is required", "error")
+            return redirect(url_for("library.edit_document", doc_id=doc_id))
+
+        content = request.form.get("content", "")
+        document.title = title
+        document.encrypted_content = (
+            encrypt_data(encryption_key, content) if content else None
+        )
+        document.updated_at = datetime.utcnow()
+        db.session.commit()
+
+        flash("Document updated successfully!", "success")
+        return redirect(url_for("library.view_document", doc_id=doc_id))
+
+    try:
+        content = (
+            decrypt_data(encryption_key, document.encrypted_content)
+            if document.encrypted_content
+            else ""
+        )
+    except Exception as exc:
+        current_app.logger.error(
+            f"Error decrypting document {doc_id}: {exc}", exc_info=True
+        )
+        content = ""
+
+    return render_template(
+        "library/document_form.html",
+        document=document,
+        content=content,
+        form_action=url_for("library.edit_document", doc_id=doc_id),
+        cancel_url=url_for("library.view_document", doc_id=doc_id),
+        page_title="Edit Document",
+    )
+
+
+@library_bp.route("/delete/<int:doc_id>", methods=["POST"])
+def delete_document(doc_id):
+    if "user_id" not in session:
+        return redirect(url_for("auth.login"))
+
+    document = Document.query.get_or_404(doc_id)
+    if document.user_id != session["user_id"]:
+        flash("Unauthorized access", "error")
+        return redirect(url_for("library.index"))
+
+    for attachment in list(document.attachments):
+        _delete_attachment_file(attachment)
+    db.session.delete(document)
+    db.session.commit()
+
+    flash("Document deleted successfully", "success")
+    return redirect(url_for("library.index"))
+
+
+# ============== Library Attachment Routes ==============
+
+
+@library_bp.route("/attachment/upload/<int:doc_id>", methods=["POST"])
+def upload_attachment(doc_id):
+    """Upload and encrypt a file attachment for a library document."""
+    if "user_id" not in session:
+        return jsonify({"error": "Not authenticated"}), 401
+
+    document = Document.query.get_or_404(doc_id)
+    if document.user_id != session["user_id"]:
+        return jsonify({"error": "Unauthorized access"}), 403
+
+    if "file" not in request.files:
+        return jsonify({"error": "No file provided"}), 400
+
+    file = request.files["file"]
+    if file.filename == "":
+        return jsonify({"error": "No file selected"}), 400
+
+    if not DocumentAttachment.allowed_file(file.filename):
+        return (
+            jsonify(
+                {
+                    "error": f'File type not allowed. Allowed types: {", ".join(DocumentAttachment.ALLOWED_EXTENSIONS)}'
+                }
+            ),
+            400,
+        )
+
+    file_content = file.read()
+    if len(file_content) > DocumentAttachment.MAX_FILE_SIZE:
+        return (
+            jsonify(
+                {
+                    "error": f"File too large. Maximum size is {DocumentAttachment.MAX_FILE_SIZE // (1024 * 1024)}MB"
+                }
+            ),
+            400,
+        )
+
+    encryption_key = get_user_encryption_key()
+    if not encryption_key:
+        return jsonify({"error": "Error retrieving encryption key"}), 500
+
+    try:
+        encrypted_content = encrypt_binary(encryption_key, file_content)
+        storage_filename = f"{uuid.uuid4()}.enc"
+        storage_path = Path(current_app.config["ATTACHMENTS_DIR"]) / storage_filename
+        storage_path.write_bytes(encrypted_content)
+
+        mime_type = (
+            file.content_type
+            or mimetypes.guess_type(file.filename)[0]
+            or "application/octet-stream"
+        )
+
+        attachment = DocumentAttachment(
+            document_id=doc_id,
+            original_filename=file.filename,
+            mime_type=mime_type,
+            file_size=len(file_content),
+            storage_filename=storage_filename,
+        )
+
+        db.session.add(attachment)
+        db.session.commit()
+
+        return jsonify(
+            {
+                "success": True,
+                "attachment": {
+                    "id": attachment.id,
+                    "filename": attachment.original_filename,
+                    "size": attachment.file_size,
+                    "mime_type": attachment.mime_type,
+                },
+            }
+        )
+    except Exception as exc:
+        db.session.rollback()
+        return jsonify({"error": f"Error uploading file: {exc}"}), 500
+
+
+@library_bp.route("/attachment/upload-clipboard/<int:doc_id>", methods=["POST"])
+def upload_clipboard_image(doc_id):
+    """Upload an image from the clipboard (base64 data) for a library document."""
+    if "user_id" not in session:
+        return jsonify({"error": "Not authenticated"}), 401
+
+    document = Document.query.get_or_404(doc_id)
+    if document.user_id != session["user_id"]:
+        return jsonify({"error": "Unauthorized access"}), 403
+
+    data = request.get_json()
+    if not data or "image_data" not in data:
+        return jsonify({"error": "No image data provided"}), 400
+
+    image_data = data["image_data"]
+    filename = data.get("filename", "clipboard_image.png")
+
+    if "," in image_data:
+        header, base64_data = image_data.split(",", 1)
+        if "image/png" in header:
+            mime_type = "image/png"
+            if not filename.endswith(".png"):
+                filename = (
+                    filename.rsplit(".", 1)[0] + ".png"
+                    if "." in filename
+                    else filename + ".png"
+                )
+        elif "image/jpeg" in header or "image/jpg" in header:
+            mime_type = "image/jpeg"
+            if not filename.endswith((".jpg", ".jpeg")):
+                filename = (
+                    filename.rsplit(".", 1)[0] + ".jpg"
+                    if "." in filename
+                    else filename + ".jpg"
+                )
+        elif "image/gif" in header:
+            mime_type = "image/gif"
+            if not filename.endswith(".gif"):
+                filename = (
+                    filename.rsplit(".", 1)[0] + ".gif"
+                    if "." in filename
+                    else filename + ".gif"
+                )
+        elif "image/webp" in header:
+            mime_type = "image/webp"
+            if not filename.endswith(".webp"):
+                filename = (
+                    filename.rsplit(".", 1)[0] + ".webp"
+                    if "." in filename
+                    else filename + ".webp"
+                )
+        else:
+            mime_type = "image/png"
+    else:
+        base64_data = image_data
+        mime_type = "image/png"
+
+    try:
+        file_content = base64.b64decode(base64_data)
+    except Exception:
+        return jsonify({"error": "Invalid base64 image data"}), 400
+
+    if len(file_content) > DocumentAttachment.MAX_FILE_SIZE:
+        return (
+            jsonify(
+                {
+                    "error": f"Image too large. Maximum size is {DocumentAttachment.MAX_FILE_SIZE // (1024 * 1024)}MB"
+                }
+            ),
+            400,
+        )
+
+    encryption_key = get_user_encryption_key()
+    if not encryption_key:
+        return jsonify({"error": "Error retrieving encryption key"}), 500
+
+    try:
+        encrypted_content = encrypt_binary(encryption_key, file_content)
+        storage_filename = f"{uuid.uuid4()}.enc"
+        storage_path = Path(current_app.config["ATTACHMENTS_DIR"]) / storage_filename
+        storage_path.write_bytes(encrypted_content)
+
+        attachment = DocumentAttachment(
+            document_id=doc_id,
+            original_filename=filename,
+            mime_type=mime_type,
+            file_size=len(file_content),
+            storage_filename=storage_filename,
+        )
+
+        db.session.add(attachment)
+        db.session.commit()
+
+        return jsonify(
+            {
+                "success": True,
+                "attachment": {
+                    "id": attachment.id,
+                    "filename": attachment.original_filename,
+                    "size": attachment.file_size,
+                    "mime_type": attachment.mime_type,
+                },
+            }
+        )
+    except Exception as exc:
+        db.session.rollback()
+        return jsonify({"error": f"Error uploading clipboard image: {exc}"}), 500
+
+
+@library_bp.route("/attachment/download/<attachment_id>")
+def download_attachment(attachment_id):
+    """Download and decrypt a library document attachment."""
+    if "user_id" not in session:
+        return jsonify({"error": "Not authenticated"}), 401
+
+    attachment = DocumentAttachment.query.get_or_404(attachment_id)
+    document = Document.query.get_or_404(attachment.document_id)
+
+    if document.user_id != session["user_id"]:
+        return jsonify({"error": "Unauthorized access"}), 403
+
+    encryption_key = get_user_encryption_key()
+    if not encryption_key:
+        return jsonify({"error": "Error retrieving encryption key"}), 500
+
+    try:
+        storage_path = (
+            Path(current_app.config["ATTACHMENTS_DIR"]) / attachment.storage_filename
+        )
+        if not storage_path.exists():
+            return jsonify({"error": "Attachment file not found"}), 404
+
+        encrypted_content = storage_path.read_bytes()
+        decrypted_content = decrypt_binary(encryption_key, encrypted_content)
+
+        return send_file(
+            BytesIO(decrypted_content),
+            mimetype=attachment.mime_type,
+            as_attachment=True,
+            download_name=attachment.original_filename,
+        )
+    except Exception as exc:
+        return jsonify({"error": f"Error downloading file: {exc}"}), 500
+
+
+@library_bp.route("/attachment/delete/<attachment_id>", methods=["POST"])
+def delete_attachment(attachment_id):
+    """Delete a library document attachment."""
+    if "user_id" not in session:
+        return jsonify({"error": "Not authenticated"}), 401
+
+    attachment = DocumentAttachment.query.get_or_404(attachment_id)
+    document = Document.query.get_or_404(attachment.document_id)
+
+    if document.user_id != session["user_id"]:
+        return jsonify({"error": "Unauthorized access"}), 403
+
+    try:
+        _delete_attachment_file(attachment)
+        db.session.delete(attachment)
+        db.session.commit()
+        return jsonify({"success": True})
+    except Exception as exc:
+        db.session.rollback()
+        return jsonify({"error": f"Error deleting attachment: {exc}"}), 500
+
+
+@library_bp.route("/attachment/list/<int:doc_id>")
+def list_attachments(doc_id):
+    """List all attachments for a library document."""
+    if "user_id" not in session:
+        return jsonify({"error": "Not authenticated"}), 401
+
+    document = Document.query.get_or_404(doc_id)
+    if document.user_id != session["user_id"]:
+        return jsonify({"error": "Unauthorized access"}), 403
+
+    attachments = [
+        {
+            "id": att.id,
+            "filename": att.original_filename,
+            "size": att.file_size,
+            "mime_type": att.mime_type,
+            "created_at": att.created_at.isoformat(),
+        }
+        for att in document.attachments
+    ]
+
+    return jsonify({"attachments": attachments})
+
+
+@library_bp.route("/attachment/preview/<attachment_id>")
+def preview_attachment(attachment_id):
+    """Return attachment content for preview (base64 JSON or inline PDF)."""
+    if "user_id" not in session:
+        return jsonify({"error": "Not authenticated"}), 401
+
+    attachment = DocumentAttachment.query.get_or_404(attachment_id)
+    document = Document.query.get_or_404(attachment.document_id)
+
+    if document.user_id != session["user_id"]:
+        return jsonify({"error": "Unauthorized access"}), 403
+
+    encryption_key = get_user_encryption_key()
+    if not encryption_key:
+        return jsonify({"error": "Error retrieving encryption key"}), 500
+
+    try:
+        storage_path = (
+            Path(current_app.config["ATTACHMENTS_DIR"]) / attachment.storage_filename
+        )
+        if not storage_path.exists():
+            return jsonify({"error": "Attachment file not found"}), 404
+
+        encrypted_content = storage_path.read_bytes()
+        decrypted_content = decrypt_binary(encryption_key, encrypted_content)
+
+        if attachment.mime_type == "application/pdf":
+            return send_file(
+                BytesIO(decrypted_content),
+                mimetype=attachment.mime_type,
+                as_attachment=False,
+                download_name=attachment.original_filename,
+            )
+
+        content_base64 = base64.b64encode(decrypted_content).decode("utf-8")
+        return jsonify(
+            {
+                "success": True,
+                "content": content_base64,
+                "mime_type": attachment.mime_type,
+                "filename": attachment.original_filename,
+            }
+        )
+    except Exception as exc:
+        return jsonify({"error": f"Error viewing attachment: {exc}"}), 500

--- a/pwd_manager/models.py
+++ b/pwd_manager/models.py
@@ -1,15 +1,18 @@
-from pwd_manager import db, bcrypt
 import os
 import uuid
-from datetime import datetime
 from base64 import b64encode
+from datetime import datetime
+
+from pwd_manager import bcrypt, db
+
 
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(50), unique=True, nullable=False)
     password = db.Column(db.String(255), nullable=False)
     encryption_key = db.Column(db.String(255), nullable=False)
-    passwords = db.relationship('SecretEntry', backref='owner', lazy=True)
+    passwords = db.relationship("SecretEntry", backref="owner", lazy=True)
+    documents = db.relationship("Document", backref="owner", lazy=True)
 
     def __init__(self, username, password=None):
         self.username = username
@@ -17,59 +20,130 @@ class User(db.Model):
             self.set_password(password)
         else:
             # For testing purposes, set a dummy password and encryption key
-            self.password = 'dummy_hash'
-            self.encryption_key = b64encode(os.urandom(32)).decode('utf-8')
+            self.password = "dummy_hash"
+            self.encryption_key = b64encode(os.urandom(32)).decode("utf-8")
 
     def set_password(self, password):
         """Hash the password and generate encryption key"""
-        self.password = bcrypt.generate_password_hash(password).decode('utf-8')
+        self.password = bcrypt.generate_password_hash(password).decode("utf-8")
         # Generate a random encryption key
-        self.encryption_key = b64encode(os.urandom(32)).decode('utf-8')
+        self.encryption_key = b64encode(os.urandom(32)).decode("utf-8")
 
     def check_password(self, password):
         """Check if the provided password is correct"""
         return bcrypt.check_password_hash(self.password, password)
 
+
 class SecretEntry(db.Model):
-    __tablename__ = 'password_entry'  # Keep existing table name to preserve data
-    
+    __tablename__ = "password_entry"  # Keep existing table name to preserve data
+
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     title = db.Column(db.String(200), nullable=False)
     has_login_info = db.Column(db.Boolean, default=False, nullable=False)
     website = db.Column(db.String(100), nullable=True)
     username = db.Column(db.String(100), nullable=True)
     encrypted_password = db.Column(db.String(255), nullable=True)
-    tags = db.Column(db.String(255), nullable=True)  # Store tags as comma-separated string
+    tags = db.Column(
+        db.String(255), nullable=True
+    )  # Store tags as comma-separated string
     notes = db.Column(db.Text, nullable=True)
-    attachments = db.relationship('Attachment', backref='secret', lazy=True, cascade='all, delete-orphan')
+    attachments = db.relationship(
+        "Attachment", backref="secret", lazy=True, cascade="all, delete-orphan"
+    )
 
 
 class Attachment(db.Model):
     """Model for encrypted file attachments linked to secrets"""
-    __tablename__ = 'attachment'
-    
+
+    __tablename__ = "attachment"
+
     id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
-    secret_entry_id = db.Column(db.Integer, db.ForeignKey('password_entry.id'), nullable=False)
+    secret_entry_id = db.Column(
+        db.Integer, db.ForeignKey("password_entry.id"), nullable=False
+    )
     original_filename = db.Column(db.String(255), nullable=False)
     mime_type = db.Column(db.String(100), nullable=False)
     file_size = db.Column(db.Integer, nullable=False)  # Size in bytes before encryption
-    storage_filename = db.Column(db.String(255), nullable=False)  # UUID-based filename on disk
+    storage_filename = db.Column(
+        db.String(255), nullable=False
+    )  # UUID-based filename on disk
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
-    
+
     # Maximum file size: 10MB
     MAX_FILE_SIZE = 10 * 1024 * 1024
-    
+
     # Allowed file extensions
-    ALLOWED_EXTENSIONS = {
-        'pdf', 'doc', 'docx', 'txt', 'rtf',  # Documents
-        'png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp',  # Images
-        'xls', 'xlsx', 'csv',  # Spreadsheets
-        'json', 'xml'  # Data files
-    }
-    
+    ALLOWED_EXTENSIONS = frozenset(
+        {
+            "pdf",
+            "doc",
+            "docx",
+            "txt",
+            "rtf",  # Documents
+            "png",
+            "jpg",
+            "jpeg",
+            "gif",
+            "bmp",
+            "webp",  # Images
+            "xls",
+            "xlsx",
+            "csv",  # Spreadsheets
+            "json",
+            "xml",  # Data files
+        }
+    )
+
     @classmethod
     def allowed_file(cls, filename):
         """Check if the file extension is allowed"""
-        return '.' in filename and \
-               filename.rsplit('.', 1)[1].lower() in cls.ALLOWED_EXTENSIONS
+        return (
+            "." in filename
+            and filename.rsplit(".", 1)[1].lower() in cls.ALLOWED_EXTENSIONS
+        )
+
+
+class Document(db.Model):
+    __tablename__ = "document"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    title = db.Column(db.String(200), nullable=False)
+    encrypted_content = db.Column(db.Text, nullable=True)
+    is_draft = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+    attachments = db.relationship(
+        "DocumentAttachment",
+        backref="document",
+        lazy=True,
+        cascade="all, delete-orphan",
+    )
+
+
+class DocumentAttachment(db.Model):
+    """Model for encrypted file attachments linked to library documents"""
+
+    __tablename__ = "document_attachment"
+
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    document_id = db.Column(db.Integer, db.ForeignKey("document.id"), nullable=False)
+    original_filename = db.Column(db.String(255), nullable=False)
+    mime_type = db.Column(db.String(100), nullable=False)
+    file_size = db.Column(db.Integer, nullable=False)
+    storage_filename = db.Column(db.String(255), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    MAX_FILE_SIZE = Attachment.MAX_FILE_SIZE
+    ALLOWED_EXTENSIONS = Attachment.ALLOWED_EXTENSIONS
+
+    @classmethod
+    def allowed_file(cls, filename):
+        """Check if the file extension is allowed"""
+        return (
+            "." in filename
+            and filename.rsplit(".", 1)[1].lower() in cls.ALLOWED_EXTENSIONS
+        )

--- a/pwd_manager/routes.py
+++ b/pwd_manager/routes.py
@@ -22,6 +22,7 @@ from flask import (
 
 from pwd_manager import db
 from pwd_manager.models import Attachment, SecretEntry, User
+from pwd_manager.utils.auth import get_user_encryption_key
 from pwd_manager.utils.crypto import (
     decrypt_binary,
     decrypt_data,
@@ -30,13 +31,6 @@ from pwd_manager.utils.crypto import (
 )
 
 main_bp = Blueprint("main", __name__)
-
-
-def get_user_encryption_key():
-    user = User.query.get(session.get("user_id"))
-    if user:
-        return user.encryption_key.encode()
-    return None
 
 
 @main_bp.route("/")
@@ -250,7 +244,7 @@ def edit_secret(entry_id):
             return redirect(url_for("main.index"))
         except Exception as e:
             db.session.rollback()
-            flash(f"Error updating secret entry: {str(e)}", "danger")
+            flash(f"Error updating secret entry: {e!s}", "danger")
             return redirect(url_for("main.edit_secret", entry_id=entry_id))
 
     # For GET request, decrypt the password and notes for display
@@ -450,7 +444,7 @@ def upload_attachment(entry_id):
 
     except Exception as e:
         db.session.rollback()
-        return jsonify({"error": f"Error uploading file: {str(e)}"}), 500
+        return jsonify({"error": f"Error uploading file: {e!s}"}), 500
 
 
 @main_bp.route("/attachment/upload-clipboard/<int:entry_id>", methods=["POST"])
@@ -570,7 +564,7 @@ def upload_clipboard_image(entry_id):
 
     except Exception as e:
         db.session.rollback()
-        return jsonify({"error": f"Error uploading clipboard image: {str(e)}"}), 500
+        return jsonify({"error": f"Error uploading clipboard image: {e!s}"}), 500
 
 
 @main_bp.route("/attachment/download/<attachment_id>")
@@ -611,7 +605,7 @@ def download_attachment(attachment_id):
         )
 
     except Exception as e:
-        return jsonify({"error": f"Error downloading file: {str(e)}"}), 500
+        return jsonify({"error": f"Error downloading file: {e!s}"}), 500
 
 
 @main_bp.route("/attachment/delete/<attachment_id>", methods=["POST"])
@@ -642,7 +636,7 @@ def delete_attachment(attachment_id):
 
     except Exception as e:
         db.session.rollback()
-        return jsonify({"error": f"Error deleting attachment: {str(e)}"}), 500
+        return jsonify({"error": f"Error deleting attachment: {e!s}"}), 500
 
 
 @main_bp.route("/attachment/list/<int:entry_id>")
@@ -723,4 +717,4 @@ def preview_attachment(attachment_id):
         )
 
     except Exception as e:
-        return jsonify({"error": f"Error viewing attachment: {str(e)}"}), 500
+        return jsonify({"error": f"Error viewing attachment: {e!s}"}), 500

--- a/pwd_manager/templates/index.html
+++ b/pwd_manager/templates/index.html
@@ -13,6 +13,9 @@
                 </div>
             </div>
 
+            {% set active_tab = 'secrets' %}
+            {% include 'partials/tabs.html' %}
+
             <div class="row mb-4">
                 <div class="col-md-6">
                     <div class="input-group">

--- a/pwd_manager/templates/library/document_form.html
+++ b/pwd_manager/templates/library/document_form.html
@@ -1,0 +1,540 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page_title }} - Password Manager{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-md-12">
+        <h2 class="text-center mb-4">{{ page_title }}</h2>
+        <div class="card">
+            <div class="card-body">
+                <form method="POST" action="{{ form_action }}" id="documentForm">
+                    {% if document.is_draft %}
+                        <input type="hidden" name="document_id" value="{{ document.id }}">
+                    {% endif %}
+                    <div class="mb-3">
+                        <label for="title" class="form-label">Title</label>
+                        <input type="text" class="form-control" id="title" name="title" value="{{ document.title }}" required placeholder="Document title">
+                    </div>
+                    <div class="mb-3">
+                        <label for="content" class="form-label">Markdown Content</label>
+                        <textarea class="form-control" id="content" name="content" rows="10" placeholder="Write your markdown here...">{{ content }}</textarea>
+                    </div>
+                </form>
+
+                <!-- Attachments Section (outside form to avoid form submission issues) -->
+                <div class="mb-3">
+                    <label class="form-label">Attachments</label>
+                    <div class="border rounded p-3">
+                        <div id="dropZone" class="border rounded p-2 text-center mb-2" style="border-style: dashed !important; cursor: pointer; background-color: var(--card-bg); border-color: var(--border-color) !important; transition: all 0.2s ease;">
+                            <input type="file" id="attachmentFile" style="display: none;" accept=".pdf,.doc,.docx,.txt,.rtf,.png,.jpg,.jpeg,.gif,.bmp,.webp,.xls,.xlsx,.csv,.json,.xml">
+                            <div id="dropZoneDefault">
+                                <p class="mb-0"><strong>Drop files here</strong>, <a href="#" id="browseLink">browse</a>, or paste an image</p>
+                                <small class="text-muted">Max 10MB</small>
+                            </div>
+                            <div id="dropZoneDragOver" style="display: none;">
+                                <p class="mb-0"><strong>Drop to upload</strong></p>
+                            </div>
+                        </div>
+
+                        <div id="filePreview" class="mb-2" style="display: none;">
+                            <div class="d-flex align-items-center gap-2 p-2 border rounded" style="background-color: var(--card-bg); border-color: var(--border-color) !important;">
+                                <img id="previewThumbnail" style="max-height: 60px; max-width: 100px; display: none;" class="border rounded">
+                                <span id="previewFileIcon" style="font-size: 2rem; display: none;"></span>
+                                <div class="flex-grow-1">
+                                    <input type="text" class="form-control form-control-sm" id="previewFilename" placeholder="Filename">
+                                    <small class="text-muted" id="previewFileSize"></small>
+                                </div>
+                                <button class="btn btn-sm btn-primary" type="button" id="confirmUploadBtn">Upload</button>
+                                <button class="btn btn-sm btn-outline-secondary" type="button" id="cancelUploadBtn">Cancel</button>
+                            </div>
+                        </div>
+
+                        <div id="uploadProgress" class="progress mb-3" style="display: none;">
+                            <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 100%"></div>
+                        </div>
+
+                        <div id="attachmentsList">
+                            <p class="text-muted mb-0" id="noAttachments">No attachments yet.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="text-center mt-4">
+                    <a href="{{ cancel_url }}" class="btn btn-secondary me-2">Cancel</a>
+                    <button type="submit" form="documentForm" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Attachment Preview Modal -->
+<div class="modal fade" id="attachmentPreviewModal" tabindex="-1" aria-labelledby="attachmentPreviewModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="attachmentPreviewModalLabel">Attachment Preview</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body text-center">
+                <div id="previewLoading" class="py-5">
+                    <div class="spinner-border" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                    <p class="mt-2">Loading preview...</p>
+                </div>
+                <div id="previewContent" style="display: none;">
+                    <img id="previewImage" class="img-fluid" style="max-height: 60vh; display: none;" alt="Preview">
+                    <iframe id="previewPdf" style="width: 100%; height: 60vh; border: none; display: none;"></iframe>
+                    <pre id="previewText" class="text-start p-3 border rounded" style="max-height: 60vh; overflow: auto; display: none;"></pre>
+                    <div id="previewUnsupported" style="display: none;" class="py-5">
+                        <p class="mt-3">Preview not available for this file type.</p>
+                        <p class="text-muted">Click Download to view the file.</p>
+                    </div>
+                </div>
+                <div id="previewFileInfo" class="mt-3 text-muted small" style="display: none;">
+                    <span id="previewFilename"></span> &bull; <span id="previewFileSize"></span>
+                </div>
+            </div>
+            <div class="modal-footer justify-content-between">
+                <div>
+                    <button type="button" class="btn btn-outline-secondary" id="prevAttachmentBtn" title="Previous">
+                        <span>&larr;</span> Previous
+                    </button>
+                    <span id="attachmentCounter" class="mx-3"></span>
+                    <button type="button" class="btn btn-outline-secondary" id="nextAttachmentBtn" title="Next">
+                        Next <span>&rarr;</span>
+                    </button>
+                </div>
+                <div>
+                    <a href="#" class="btn btn-primary" id="previewDownloadBtn">Download</a>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+const docId = Number('{{ document.id }}');
+const uploadUrl = "{{ url_for('library.upload_attachment', doc_id=document.id) }}";
+const uploadClipboardUrl = "{{ url_for('library.upload_clipboard_image', doc_id=document.id) }}";
+const listUrl = "{{ url_for('library.list_attachments', doc_id=document.id) }}";
+let attachmentsList = [];
+let currentAttachmentIndex = 0;
+
+function formatFileSize(bytes) {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+function getFileIcon(mimeType) {
+    if (mimeType.startsWith('image/')) return 'IMG';
+    if (mimeType.includes('pdf')) return 'PDF';
+    if (mimeType.includes('word') || mimeType.includes('document')) return 'DOC';
+    if (mimeType.includes('sheet') || mimeType.includes('excel') || mimeType.includes('csv')) return 'XLS';
+    return 'FILE';
+}
+
+function loadAttachments() {
+    fetch(listUrl)
+        .then(response => response.json())
+        .then(data => {
+            const container = document.getElementById('attachmentsList');
+            const noAttachments = document.getElementById('noAttachments');
+
+            const existingItems = container.querySelectorAll('.attachment-item');
+            existingItems.forEach(item => item.remove());
+
+            attachmentsList = data.attachments || [];
+
+            if (attachmentsList.length > 0) {
+                noAttachments.style.display = 'none';
+
+                attachmentsList.forEach((att, index) => {
+                    const item = document.createElement('div');
+                    item.className = 'attachment-item d-flex justify-content-between align-items-center p-2 border-bottom';
+                    item.innerHTML = `
+                        <div>
+                            <span class="me-2">${getFileIcon(att.mime_type)}</span>
+                            <span class="attachment-clickable" onclick="openPreview(${index})" style="cursor: pointer;">${att.filename}</span>
+                            <small class="text-muted ms-2">(${formatFileSize(att.size)})</small>
+                        </div>
+                        <div>
+                            <a href="/library/attachment/download/${att.id}" class="btn btn-sm btn-outline-primary me-1">Download</a>
+                            <button class="btn btn-sm btn-outline-danger" onclick="deleteAttachment('${att.id}')">Delete</button>
+                        </div>
+                    `;
+                    container.appendChild(item);
+                });
+            } else {
+                noAttachments.style.display = 'block';
+            }
+        })
+        .catch(error => {
+            console.error('Error loading attachments:', error);
+        });
+}
+
+function deleteAttachment(attachmentId) {
+    if (!confirm('Are you sure you want to delete this attachment?')) {
+        return;
+    }
+
+    fetch(`/library/attachment/delete/${attachmentId}`, {
+        method: 'POST'
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            loadAttachments();
+        } else {
+            alert('Error: ' + data.error);
+        }
+    })
+    .catch(error => {
+        alert('Error deleting attachment: ' + error);
+    });
+}
+
+loadAttachments();
+
+const dropZone = document.getElementById('dropZone');
+const dropZoneDefault = document.getElementById('dropZoneDefault');
+const dropZoneDragOver = document.getElementById('dropZoneDragOver');
+const fileInput = document.getElementById('attachmentFile');
+const browseLink = document.getElementById('browseLink');
+const filePreview = document.getElementById('filePreview');
+const previewThumbnail = document.getElementById('previewThumbnail');
+const previewFileIcon = document.getElementById('previewFileIcon');
+const previewFilename = document.getElementById('previewFilename');
+const previewFileSize = document.getElementById('previewFileSize');
+const confirmUploadBtn = document.getElementById('confirmUploadBtn');
+const cancelUploadBtn = document.getElementById('cancelUploadBtn');
+const documentForm = document.getElementById('documentForm');
+
+let pendingFile = null;
+let pendingClipboardData = null;
+let submitAfterUpload = false;
+
+browseLink.addEventListener('click', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    fileInput.click();
+});
+
+dropZone.addEventListener('click', function(e) {
+    if (e.target !== browseLink) {
+        dropZone.focus();
+    }
+});
+
+dropZone.setAttribute('tabindex', '0');
+
+fileInput.addEventListener('change', function() {
+    if (this.files && this.files[0]) {
+        showFilePreview(this.files[0]);
+    }
+});
+
+dropZone.addEventListener('dragover', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    dropZoneDefault.style.display = 'none';
+    dropZoneDragOver.style.display = 'block';
+    dropZone.style.backgroundColor = '#e3f2fd';
+    dropZone.style.borderColor = '#2196f3';
+});
+
+dropZone.addEventListener('dragleave', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    resetDropZoneStyle();
+});
+
+dropZone.addEventListener('drop', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    resetDropZoneStyle();
+
+    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+        showFilePreview(e.dataTransfer.files[0]);
+    }
+});
+
+function resetDropZoneStyle() {
+    dropZoneDefault.style.display = 'block';
+    dropZoneDragOver.style.display = 'none';
+    dropZone.style.backgroundColor = '';
+    dropZone.style.borderColor = '';
+}
+
+dropZone.addEventListener('paste', handlePaste);
+document.addEventListener('paste', function(e) {
+    const activeElement = document.activeElement;
+    const isInputFocused = activeElement.tagName === 'INPUT' ||
+                           activeElement.tagName === 'TEXTAREA' ||
+                           activeElement.isContentEditable;
+
+    if (!isInputFocused) {
+        handlePaste(e);
+    }
+});
+
+function handlePaste(e) {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    for (let i = 0; i < items.length; i++) {
+        if (items[i].type.indexOf('image') !== -1) {
+            e.preventDefault();
+            const blob = items[i].getAsFile();
+            const reader = new FileReader();
+
+            reader.onload = function(event) {
+                pendingClipboardData = event.target.result;
+                pendingFile = null;
+
+                const now = new Date();
+                const timestamp = now.toISOString().replace(/[:.]/g, '-').slice(0, 19);
+                const filename = `clipboard_${timestamp}.png`;
+
+                previewThumbnail.src = pendingClipboardData;
+                previewThumbnail.style.display = 'block';
+                previewFileIcon.style.display = 'none';
+                previewFilename.value = filename;
+                previewFileSize.textContent = formatFileSize(blob.size);
+
+                dropZone.style.display = 'none';
+                filePreview.style.display = 'block';
+            };
+
+            reader.readAsDataURL(blob);
+            break;
+        }
+    }
+}
+
+function showFilePreview(file) {
+    pendingFile = file;
+    pendingClipboardData = null;
+
+    previewFilename.value = file.name;
+    previewFileSize.textContent = formatFileSize(file.size);
+
+    if (file.type.startsWith('image/')) {
+        const reader = new FileReader();
+        reader.onload = function(e) {
+            previewThumbnail.src = e.target.result;
+            previewThumbnail.style.display = 'block';
+            previewFileIcon.style.display = 'none';
+        };
+        reader.readAsDataURL(file);
+    } else {
+        previewThumbnail.style.display = 'none';
+        previewFileIcon.textContent = getFileIcon(file.type);
+        previewFileIcon.style.display = 'block';
+    }
+
+    dropZone.style.display = 'none';
+    filePreview.style.display = 'block';
+}
+
+confirmUploadBtn.addEventListener('click', function() {
+    const progressBar = document.getElementById('uploadProgress');
+    progressBar.style.display = 'block';
+
+    if (pendingClipboardData) {
+        const filename = previewFilename.value.trim() || 'clipboard_image.png';
+
+        fetch(uploadClipboardUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                image_data: pendingClipboardData,
+                filename: filename
+            })
+        })
+        .then(response => response.json())
+        .then(data => {
+            progressBar.style.display = 'none';
+            if (data.success) {
+                resetPreview();
+                loadAttachments();
+                if (submitAfterUpload) {
+                    documentForm.submit();
+                }
+            } else {
+                submitAfterUpload = false;
+                alert('Error: ' + data.error);
+            }
+        })
+        .catch(error => {
+            progressBar.style.display = 'none';
+            submitAfterUpload = false;
+            alert('Error uploading: ' + error);
+        });
+    } else if (pendingFile) {
+        const formData = new FormData();
+        const newFilename = previewFilename.value.trim();
+        if (newFilename && newFilename !== pendingFile.name) {
+            const renamedFile = new File([pendingFile], newFilename, { type: pendingFile.type });
+            formData.append('file', renamedFile);
+        } else {
+            formData.append('file', pendingFile);
+        }
+
+        fetch(uploadUrl, {
+            method: 'POST',
+            body: formData
+        })
+        .then(response => response.json())
+        .then(data => {
+            progressBar.style.display = 'none';
+            if (data.success) {
+                resetPreview();
+                loadAttachments();
+                if (submitAfterUpload) {
+                    documentForm.submit();
+                }
+            } else {
+                submitAfterUpload = false;
+                alert('Error: ' + data.error);
+            }
+        })
+        .catch(error => {
+            progressBar.style.display = 'none';
+            submitAfterUpload = false;
+            alert('Error uploading: ' + error);
+        });
+    }
+});
+
+cancelUploadBtn.addEventListener('click', resetPreview);
+
+documentForm.addEventListener('submit', function(e) {
+    if (pendingFile || pendingClipboardData) {
+        e.preventDefault();
+        submitAfterUpload = true;
+        confirmUploadBtn.click();
+    }
+});
+
+function resetPreview() {
+    pendingFile = null;
+    pendingClipboardData = null;
+    fileInput.value = '';
+    previewThumbnail.src = '';
+    previewThumbnail.style.display = 'none';
+    previewFileIcon.style.display = 'none';
+    previewFilename.value = '';
+    previewFileSize.textContent = '';
+    filePreview.style.display = 'none';
+    dropZone.style.display = 'block';
+}
+
+const previewModal = new bootstrap.Modal(document.getElementById('attachmentPreviewModal'));
+
+function openPreview(index) {
+    currentAttachmentIndex = index;
+    showPreview();
+    previewModal.show();
+}
+
+function showPreview() {
+    const att = attachmentsList[currentAttachmentIndex];
+    if (!att) return;
+
+    document.getElementById('attachmentCounter').textContent = `${currentAttachmentIndex + 1} / ${attachmentsList.length}`;
+    document.getElementById('prevAttachmentBtn').disabled = currentAttachmentIndex === 0;
+    document.getElementById('nextAttachmentBtn').disabled = currentAttachmentIndex === attachmentsList.length - 1;
+    document.getElementById('previewDownloadBtn').href = `/library/attachment/download/${att.id}`;
+    document.getElementById('attachmentPreviewModalLabel').textContent = att.filename;
+    document.getElementById('previewFilename').textContent = att.filename;
+    document.getElementById('previewFileSize').textContent = formatFileSize(att.size);
+
+    document.getElementById('previewImage').style.display = 'none';
+    document.getElementById('previewPdf').style.display = 'none';
+    document.getElementById('previewText').style.display = 'none';
+    document.getElementById('previewUnsupported').style.display = 'none';
+
+    const mimeType = att.mime_type;
+
+    if (mimeType === 'application/pdf' || att.filename.toLowerCase().endsWith('.pdf')) {
+        document.getElementById('previewLoading').style.display = 'none';
+        document.getElementById('previewContent').style.display = 'block';
+        document.getElementById('previewFileInfo').style.display = 'block';
+        const iframe = document.getElementById('previewPdf');
+        iframe.src = `/library/attachment/preview/${att.id}`;
+        iframe.style.display = 'block';
+        return;
+    }
+
+    document.getElementById('previewLoading').style.display = 'block';
+    document.getElementById('previewContent').style.display = 'none';
+    document.getElementById('previewFileInfo').style.display = 'none';
+
+    fetch(`/library/attachment/preview/${att.id}`)
+        .then(response => response.json())
+        .then(data => {
+            document.getElementById('previewLoading').style.display = 'none';
+            document.getElementById('previewContent').style.display = 'block';
+            document.getElementById('previewFileInfo').style.display = 'block';
+
+            if (data.success) {
+                const contentMimeType = data.mime_type;
+                const content = data.content;
+
+                if (contentMimeType.startsWith('image/')) {
+                    const img = document.getElementById('previewImage');
+                    img.src = `data:${contentMimeType};base64,${content}`;
+                    img.style.display = 'block';
+                } else if (contentMimeType.startsWith('text/') || contentMimeType === 'application/json' || contentMimeType === 'application/xml') {
+                    const pre = document.getElementById('previewText');
+                    try {
+                        pre.textContent = atob(content);
+                    } catch (e) {
+                        pre.textContent = 'Unable to decode text content';
+                    }
+                    pre.style.display = 'block';
+                } else {
+                    document.getElementById('previewUnsupported').style.display = 'block';
+                }
+            } else {
+                document.getElementById('previewUnsupported').style.display = 'block';
+            }
+        })
+        .catch(error => {
+            console.error('Error loading preview:', error);
+            document.getElementById('previewLoading').style.display = 'none';
+            document.getElementById('previewContent').style.display = 'block';
+            document.getElementById('previewUnsupported').style.display = 'block';
+        });
+}
+
+function navigatePreview(direction) {
+    const newIndex = currentAttachmentIndex + direction;
+    if (newIndex >= 0 && newIndex < attachmentsList.length) {
+        currentAttachmentIndex = newIndex;
+        showPreview();
+    }
+}
+
+document.getElementById('prevAttachmentBtn').addEventListener('click', () => navigatePreview(-1));
+document.getElementById('nextAttachmentBtn').addEventListener('click', () => navigatePreview(1));
+
+document.addEventListener('keydown', function(e) {
+    const modal = document.getElementById('attachmentPreviewModal');
+    if (modal.classList.contains('show')) {
+        if (e.key === 'ArrowLeft') navigatePreview(-1);
+        if (e.key === 'ArrowRight') navigatePreview(1);
+    }
+});
+</script>
+{% endblock %}

--- a/pwd_manager/templates/library/index.html
+++ b/pwd_manager/templates/library/index.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+
+{% block title %}My Library - Password Manager{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-md-12">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h2>My Library</h2>
+            <div>
+                <a href="{{ url_for('library.add_document') }}" class="btn btn-primary me-2">Add New Document</a>
+                <a href="{{ url_for('auth.logout') }}" class="btn btn-outline-danger">Logout</a>
+            </div>
+        </div>
+
+        {% set active_tab = 'library' %}
+        {% include 'partials/tabs.html' %}
+
+        <div class="list-group" id="documentList">
+            {% if documents %}
+                {% for doc in documents %}
+                    <div class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                        <div class="flex-grow-1">
+                            <a href="{{ url_for('library.view_document', doc_id=doc.id) }}" class="text-decoration-none fw-bold">
+                                {{ doc.title }}
+                            </a>
+                            <br>
+                            <small class="text-muted">Updated {{ doc.updated_at.strftime('%Y-%m-%d %H:%M') }}</small>
+                        </div>
+                        <div>
+                            <a href="{{ url_for('library.view_document', doc_id=doc.id) }}" class="btn btn-sm btn-secondary me-1">View</a>
+                            <a href="{{ url_for('library.edit_document', doc_id=doc.id) }}" class="btn btn-sm btn-primary me-1">Edit</a>
+                            <form action="{{ url_for('library.delete_document', doc_id=doc.id) }}" method="POST" style="display:inline;">
+                                <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Are you sure you want to delete this document?')">Delete</button>
+                            </form>
+                        </div>
+                    </div>
+                {% endfor %}
+            {% else %}
+                <div class="alert alert-info text-center">
+                    <p>Your library is empty.</p>
+                    <a href="{{ url_for('library.add_document') }}" class="btn btn-primary mt-2">Add Your First Document</a>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/pwd_manager/templates/library/view_document.html
+++ b/pwd_manager/templates/library/view_document.html
@@ -1,0 +1,246 @@
+{% extends "base.html" %}
+
+{% block title %}{{ document.title }} - Password Manager{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-md-12">
+        <h2 class="text-center mb-4">{{ document.title }}</h2>
+        <div class="card">
+            <div class="card-body">
+                {% if content %}
+                <div class="mb-3">
+                    <label class="form-label">Content</label>
+                    <div class="form-control markdown-content" style="min-height: 60px;">{{ content|markdown }}</div>
+                </div>
+                {% else %}
+                <div class="alert alert-info">No content.</div>
+                {% endif %}
+
+                <!-- Attachments Section -->
+                <div class="mb-3">
+                    <label class="form-label">Attachments</label>
+                    <div class="border rounded p-3">
+                        <div id="attachmentsList">
+                            <p class="text-muted mb-0" id="noAttachments">No attachments.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="text-center mt-3">
+            <a href="{{ url_for('library.index') }}" class="btn btn-secondary me-2">Back to Library</a>
+            <a href="{{ url_for('library.edit_document', doc_id=document.id) }}" class="btn btn-primary">Edit</a>
+        </div>
+    </div>
+</div>
+
+<!-- Attachment Preview Modal -->
+<div class="modal fade" id="attachmentPreviewModal" tabindex="-1" aria-labelledby="attachmentPreviewModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="attachmentPreviewModalLabel">Attachment Preview</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body text-center">
+                <div id="previewLoading" class="py-5">
+                    <div class="spinner-border" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                    <p class="mt-2">Loading preview...</p>
+                </div>
+                <div id="previewContent" style="display: none;">
+                    <img id="previewImage" class="img-fluid" style="max-height: 60vh; display: none;" alt="Preview">
+                    <iframe id="previewPdf" style="width: 100%; height: 60vh; border: none; display: none;"></iframe>
+                    <pre id="previewText" class="text-start p-3 border rounded" style="max-height: 60vh; overflow: auto; display: none;"></pre>
+                    <div id="previewUnsupported" style="display: none;" class="py-5">
+                        <p class="mt-3">Preview not available for this file type.</p>
+                        <p class="text-muted">Click Download to view the file.</p>
+                    </div>
+                </div>
+                <div id="previewFileInfo" class="mt-3 text-muted small" style="display: none;">
+                    <span id="previewFilename"></span> &bull; <span id="previewFileSize"></span>
+                </div>
+            </div>
+            <div class="modal-footer justify-content-between">
+                <div>
+                    <button type="button" class="btn btn-outline-secondary" id="prevAttachmentBtn" title="Previous">
+                        <span>&larr;</span> Previous
+                    </button>
+                    <span id="attachmentCounter" class="mx-3"></span>
+                    <button type="button" class="btn btn-outline-secondary" id="nextAttachmentBtn" title="Next">
+                        Next <span>&rarr;</span>
+                    </button>
+                </div>
+                <div>
+                    <a href="#" class="btn btn-primary" id="previewDownloadBtn">Download</a>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+const docId = Number('{{ document.id }}');
+const listUrl = "{{ url_for('library.list_attachments', doc_id=document.id) }}";
+let attachmentsList = [];
+let currentAttachmentIndex = 0;
+
+function formatFileSize(bytes) {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+function getFileIcon(mimeType) {
+    if (mimeType.startsWith('image/')) return 'IMG';
+    if (mimeType.includes('pdf')) return 'PDF';
+    if (mimeType.includes('word') || mimeType.includes('document')) return 'DOC';
+    if (mimeType.includes('sheet') || mimeType.includes('excel') || mimeType.includes('csv')) return 'XLS';
+    return 'FILE';
+}
+
+function loadAttachments() {
+    fetch(listUrl)
+        .then(response => response.json())
+        .then(data => {
+            const container = document.getElementById('attachmentsList');
+            const noAttachments = document.getElementById('noAttachments');
+
+            const existingItems = container.querySelectorAll('.attachment-item');
+            existingItems.forEach(item => item.remove());
+
+            attachmentsList = data.attachments || [];
+
+            if (attachmentsList.length > 0) {
+                noAttachments.style.display = 'none';
+
+                attachmentsList.forEach((att, index) => {
+                    const item = document.createElement('div');
+                    item.className = 'attachment-item d-flex justify-content-between align-items-center p-2 border-bottom';
+                    item.innerHTML = `
+                        <div class="attachment-clickable flex-grow-1" data-index="${index}" style="cursor: pointer;">
+                            <span class="me-2">${getFileIcon(att.mime_type)}</span>
+                            <span>${att.filename}</span>
+                            <small class="text-muted ms-2">(${formatFileSize(att.size)})</small>
+                        </div>
+                        <div>
+                            <a href="/library/attachment/download/${att.id}" class="btn btn-sm btn-outline-primary" onclick="event.stopPropagation();">Download</a>
+                        </div>
+                    `;
+                    item.querySelector('.attachment-clickable').addEventListener('click', () => openPreview(index));
+                    container.appendChild(item);
+                });
+            } else {
+                noAttachments.style.display = 'block';
+            }
+        })
+        .catch(error => {
+            console.error('Error loading attachments:', error);
+        });
+}
+
+const previewModal = new bootstrap.Modal(document.getElementById('attachmentPreviewModal'));
+
+function openPreview(index) {
+    currentAttachmentIndex = index;
+    showPreview();
+    previewModal.show();
+}
+
+function showPreview() {
+    const att = attachmentsList[currentAttachmentIndex];
+    if (!att) return;
+
+    document.getElementById('attachmentCounter').textContent = `${currentAttachmentIndex + 1} / ${attachmentsList.length}`;
+    document.getElementById('prevAttachmentBtn').disabled = currentAttachmentIndex === 0;
+    document.getElementById('nextAttachmentBtn').disabled = currentAttachmentIndex === attachmentsList.length - 1;
+    document.getElementById('previewDownloadBtn').href = `/library/attachment/download/${att.id}`;
+    document.getElementById('attachmentPreviewModalLabel').textContent = att.filename;
+    document.getElementById('previewFilename').textContent = att.filename;
+    document.getElementById('previewFileSize').textContent = formatFileSize(att.size);
+
+    document.getElementById('previewImage').style.display = 'none';
+    document.getElementById('previewPdf').style.display = 'none';
+    document.getElementById('previewText').style.display = 'none';
+    document.getElementById('previewUnsupported').style.display = 'none';
+
+    const mimeType = att.mime_type;
+
+    if (mimeType === 'application/pdf' || att.filename.toLowerCase().endsWith('.pdf')) {
+        document.getElementById('previewLoading').style.display = 'none';
+        document.getElementById('previewContent').style.display = 'block';
+        document.getElementById('previewFileInfo').style.display = 'block';
+        const iframe = document.getElementById('previewPdf');
+        iframe.src = `/library/attachment/preview/${att.id}`;
+        iframe.style.display = 'block';
+        return;
+    }
+
+    document.getElementById('previewLoading').style.display = 'block';
+    document.getElementById('previewContent').style.display = 'none';
+    document.getElementById('previewFileInfo').style.display = 'none';
+
+    fetch(`/library/attachment/preview/${att.id}`)
+        .then(response => response.json())
+        .then(data => {
+            document.getElementById('previewLoading').style.display = 'none';
+            document.getElementById('previewContent').style.display = 'block';
+            document.getElementById('previewFileInfo').style.display = 'block';
+
+            if (data.success) {
+                const contentMimeType = data.mime_type;
+                const content = data.content;
+
+                if (contentMimeType.startsWith('image/')) {
+                    const img = document.getElementById('previewImage');
+                    img.src = `data:${contentMimeType};base64,${content}`;
+                    img.style.display = 'block';
+                } else if (contentMimeType.startsWith('text/') || contentMimeType === 'application/json' || contentMimeType === 'application/xml') {
+                    const pre = document.getElementById('previewText');
+                    try {
+                        pre.textContent = atob(content);
+                    } catch (e) {
+                        pre.textContent = 'Unable to decode text content';
+                    }
+                    pre.style.display = 'block';
+                } else {
+                    document.getElementById('previewUnsupported').style.display = 'block';
+                }
+            } else {
+                document.getElementById('previewUnsupported').style.display = 'block';
+            }
+        })
+        .catch(error => {
+            console.error('Error loading preview:', error);
+            document.getElementById('previewLoading').style.display = 'none';
+            document.getElementById('previewContent').style.display = 'block';
+            document.getElementById('previewUnsupported').style.display = 'block';
+        });
+}
+
+function navigatePreview(direction) {
+    const newIndex = currentAttachmentIndex + direction;
+    if (newIndex >= 0 && newIndex < attachmentsList.length) {
+        currentAttachmentIndex = newIndex;
+        showPreview();
+    }
+}
+
+document.getElementById('prevAttachmentBtn').addEventListener('click', () => navigatePreview(-1));
+document.getElementById('nextAttachmentBtn').addEventListener('click', () => navigatePreview(1));
+
+document.getElementById('attachmentPreviewModal').addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowLeft') navigatePreview(-1);
+    else if (e.key === 'ArrowRight') navigatePreview(1);
+});
+
+loadAttachments();
+</script>
+{% endblock %}

--- a/pwd_manager/templates/partials/tabs.html
+++ b/pwd_manager/templates/partials/tabs.html
@@ -1,0 +1,8 @@
+<ul class="nav nav-tabs mb-4">
+    <li class="nav-item">
+        <a class="nav-link {% if active_tab == 'secrets' %}active{% endif %}" href="{{ url_for('main.index') }}">Secrets</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link {% if active_tab == 'library' %}active{% endif %}" href="{{ url_for('library.index') }}">Library</a>
+    </li>
+</ul>

--- a/pwd_manager/utils/auth.py
+++ b/pwd_manager/utils/auth.py
@@ -1,0 +1,10 @@
+from flask import session
+from pwd_manager.models import User
+
+
+def get_user_encryption_key():
+    """Return the current user's Fernet encryption key as bytes."""
+    user = User.query.get(session.get("user_id"))
+    if user:
+        return user.encryption_key.encode()
+    return None

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,0 +1,264 @@
+import base64
+import io
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from pwd_manager import create_app, db
+from pwd_manager.models import Document, DocumentAttachment, User
+from pwd_manager.utils.crypto import decrypt_data
+
+
+class TestLibrary(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app("testing")
+        self.client = self.app.test_client()
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        db.create_all()
+
+        self.user = User(username="libuser")
+        self.user.set_password("libpass")
+        db.session.add(self.user)
+
+        self.other_user = User(username="otheruser")
+        self.other_user.set_password("otherpass")
+        db.session.add(self.other_user)
+
+        db.session.commit()
+
+        self.attachments_dir = tempfile.mkdtemp()
+        self.app.config["ATTACHMENTS_DIR"] = self.attachments_dir
+        self.key = self.user.encryption_key.encode()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        shutil.rmtree(self.attachments_dir)
+        self.app_context.pop()
+
+    def login(self, username="libuser", password="libpass"):
+        return self.client.post(
+            "/auth/login",
+            data={"username": username, "password": password},
+            follow_redirects=True,
+        )
+
+    def _upload_test_file(self, document_id, filename="test.txt", content=b"hello"):
+        return self.client.post(
+            f"/library/attachment/upload/{document_id}",
+            data={"file": (io.BytesIO(content), filename)},
+            content_type="multipart/form-data",
+        )
+
+    def test_add_creates_draft(self):
+        """GET /library/add should create a draft document"""
+        self.login()
+        count_before = Document.query.count()
+        response = self.client.get("/library/add")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Document.query.count(), count_before + 1)
+        draft = Document.query.order_by(Document.id.desc()).first()
+        self.assertTrue(draft.is_draft)
+        self.assertEqual(draft.user_id, self.user.id)
+
+    def test_add_document(self):
+        """POST /library/add should save a draft document with encrypted content"""
+        self.login()
+        self.client.get("/library/add")
+        draft = Document.query.order_by(Document.id.desc()).first()
+
+        response = self.client.post(
+            "/library/add",
+            data={
+                "document_id": draft.id,
+                "title": "My Document",
+                "content": "Some **bold** content",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        document = Document.query.get(draft.id)
+        self.assertFalse(document.is_draft)
+        self.assertEqual(document.title, "My Document")
+        self.assertEqual(
+            decrypt_data(self.key, document.encrypted_content),
+            "Some **bold** content",
+        )
+        self.assertIn(b"<strong>bold</strong>", response.data)
+
+    def test_add_document_saves_existing_attachments(self):
+        """Attachments uploaded to the draft before save should remain attached"""
+        self.login()
+        self.client.get("/library/add")
+        draft = Document.query.order_by(Document.id.desc()).first()
+
+        upload_response = self._upload_test_file(draft.id)
+        self.assertEqual(upload_response.status_code, 200)
+        self.assertTrue(upload_response.get_json()["success"])
+
+        self.client.post(
+            "/library/add",
+            data={
+                "document_id": draft.id,
+                "title": "Doc with Attachment",
+                "content": "",
+            },
+            follow_redirects=True,
+        )
+
+        document = Document.query.get(draft.id)
+        self.assertFalse(document.is_draft)
+        list_response = self.client.get(f"/library/attachment/list/{document.id}")
+        self.assertEqual(len(list_response.get_json()["attachments"]), 1)
+
+    def test_add_validation_preserves_draft(self):
+        """Missing title should not discard an already-uploaded attachment"""
+        self.login()
+        self.client.get("/library/add")
+        draft = Document.query.order_by(Document.id.desc()).first()
+
+        self._upload_test_file(draft.id)
+        response = self.client.post(
+            "/library/add",
+            data={"document_id": draft.id, "title": "", "content": "content"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Title is required", response.data)
+        self.assertIsNotNone(Document.query.get(draft.id))
+        self.assertEqual(
+            len(DocumentAttachment.query.filter_by(document_id=draft.id).all()), 1
+        )
+
+    def test_view_document_unauthorized(self):
+        """Users should not be able to view another user's document"""
+        document = Document(
+            user_id=self.user.id,
+            title="Secret",
+            encrypted_content=None,
+            is_draft=False,
+        )
+        db.session.add(document)
+        db.session.commit()
+
+        self.login("otheruser", "otherpass")
+        response = self.client.get(f"/library/{document.id}", follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Unauthorized", response.data)
+
+    def test_edit_document(self):
+        """Documents should be editable and content re-encrypted"""
+        document = Document(
+            user_id=self.user.id,
+            title="Old",
+            encrypted_content=None,
+            is_draft=False,
+        )
+        db.session.add(document)
+        db.session.commit()
+
+        self.login()
+        response = self.client.post(
+            f"/library/edit/{document.id}",
+            data={"title": "New", "content": "updated content"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        db.session.refresh(document)
+        self.assertEqual(document.title, "New")
+        self.assertEqual(
+            decrypt_data(self.key, document.encrypted_content),
+            "updated content",
+        )
+
+    def test_delete_document(self):
+        """Documents and their on-disk attachments should be deletable"""
+        document = Document(
+            user_id=self.user.id,
+            title="To Delete",
+            encrypted_content=None,
+            is_draft=False,
+        )
+        db.session.add(document)
+        db.session.commit()
+
+        self.login()
+        upload_response = self._upload_test_file(document.id)
+        attachment_id = upload_response.get_json()["attachment"]["id"]
+
+        response = self.client.post(
+            f"/library/delete/{document.id}", follow_redirects=True
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(Document.query.get(document.id))
+        self.assertIsNone(DocumentAttachment.query.get(attachment_id))
+        self.assertEqual(list(Path(self.attachments_dir).iterdir()), [])
+
+    def test_cancel_document(self):
+        """Cancel should delete the draft and any uploaded attachments"""
+        self.login()
+        self.client.get("/library/add")
+        draft = Document.query.order_by(Document.id.desc()).first()
+
+        self._upload_test_file(draft.id)
+        response = self.client.get(f"/library/cancel/{draft.id}", follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(Document.query.get(draft.id))
+        self.assertEqual(list(Path(self.attachments_dir).iterdir()), [])
+
+    def test_attachment_lifecycle(self):
+        """Upload, list, download, preview, and delete attachments"""
+        document = Document(
+            user_id=self.user.id,
+            title="With Attachments",
+            encrypted_content=None,
+            is_draft=False,
+        )
+        db.session.add(document)
+        db.session.commit()
+
+        self.login()
+        upload_response = self._upload_test_file(
+            document.id, filename="hello.txt", content=b"hello world"
+        )
+        self.assertEqual(upload_response.status_code, 200)
+        upload_data = upload_response.get_json()
+        self.assertTrue(upload_data["success"])
+        attachment_id = upload_data["attachment"]["id"]
+
+        list_response = self.client.get(f"/library/attachment/list/{document.id}")
+        self.assertEqual(len(list_response.get_json()["attachments"]), 1)
+
+        download_response = self.client.get(
+            f"/library/attachment/download/{attachment_id}"
+        )
+        self.assertEqual(download_response.status_code, 200)
+        self.assertEqual(download_response.data, b"hello world")
+
+        preview_response = self.client.get(
+            f"/library/attachment/preview/{attachment_id}"
+        )
+        self.assertEqual(preview_response.status_code, 200)
+        preview_data = preview_response.get_json()
+        self.assertTrue(preview_data["success"])
+        self.assertEqual(
+            base64.b64decode(preview_data["content"]).decode(), "hello world"
+        )
+
+        delete_response = self.client.post(
+            f"/library/attachment/delete/{attachment_id}"
+        )
+        self.assertEqual(delete_response.status_code, 200)
+        self.assertTrue(delete_response.get_json()["success"])
+        self.assertIsNone(DocumentAttachment.query.get(attachment_id))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Adds a new Library tab alongside Secrets for managing markdown documents
- Introduces Document and DocumentAttachment models
- Creates a dedicated /library blueprint with full CRUD (add/view/edit/delete)
- Supports drag/drop, browse, and clipboard paste uploads for attachments
- Reuses existing encryption infrastructure for document content and files
- Refactors get_user_encryption_key into pwd_manager.utils.auth
- Adds shared tab navigation for Secrets and Library
- Adds unit tests for the Library feature

Generated with [Devin](https://devin.ai)